### PR TITLE
Add YAML config for llm_gate

### DIFF
--- a/cultist_chan_bot/airdrop/__init__.py
+++ b/cultist_chan_bot/airdrop/__init__.py
@@ -1,0 +1,5 @@
+"""Airdrop package exports."""
+
+from .airdrop import *  # noqa: F401,F403
+from .airdrop_hunter import evaluate_airdrops, join_airdrop
+

--- a/cultist_chan_bot/airdrop/airdrop.py
+++ b/cultist_chan_bot/airdrop/airdrop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from .logger import get_logger
+from ..core.logger import get_logger
 
 DB_PATH = Path(__file__).with_name("bot.db")
 

--- a/cultist_chan_bot/airdrop/airdrop_hunter.py
+++ b/cultist_chan_bot/airdrop/airdrop_hunter.py
@@ -4,24 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from .logger import get_logger
+from ..core.logger import get_logger
 
-import asyncio
+import aiohttp
 
-from .llm import query_llm
-from .db import log_airdrop
+from ..llm import generate_reply
+from ..core.db import log_airdrop
 from .airdrop import save_airdrop_history
 
 from time import time
 
-PROMPT_FILE = Path(__file__).with_name("prompts") / "airdrop_selector.txt"
+PROMPT_FILE = Path(__file__).resolve().parents[1] / "prompts" / "airdrop_selector.txt"
 
 
-def evaluate_airdrops(drops: list[dict]) -> list[dict]:
+async def evaluate_airdrops(
+    drops: list[dict],
+    session: aiohttp.ClientSession | None = None,
+) -> list[dict]:
     """Return drops recommended by TinyLlama."""
     template = PROMPT_FILE.read_text()
     prompt = f"{template}\n{json.dumps(drops)}"
-    reply = asyncio.run(query_llm(prompt))
+    reply = await generate_reply(prompt, session=session)
 
     try:
         parsed = json.loads(reply)
@@ -40,11 +43,11 @@ def evaluate_airdrops(drops: list[dict]) -> list[dict]:
     return results
 
 
-def join_airdrop(drop: dict) -> dict:
+async def join_airdrop(drop: dict) -> dict:
     """Simulate joining an airdrop and report success."""
     name = drop.get("name", "unknown")
     get_logger(__name__).info("Joining airdrop: %s", name)
-    log_airdrop(drop, "joined")
+    await log_airdrop(drop, "joined")
     save_airdrop_history(name, "joined", time())
 
     return {"name": name, "success": True}

--- a/cultist_chan_bot/airdrop_hunter.py
+++ b/cultist_chan_bot/airdrop_hunter.py
@@ -1,0 +1,4 @@
+from .airdrop.airdrop_hunter import evaluate_airdrops, join_airdrop
+from .llm.llm import generate_reply
+from .core.db import log_airdrop
+

--- a/cultist_chan_bot/core/config.py
+++ b/cultist_chan_bot/core/config.py
@@ -17,6 +17,10 @@ class Settings(BaseSettings):
     LLM_URL: str = "http://localhost:8000/generate"
     MEMORY_PATH: str = "memory.json"
     LOG_LEVEL: str = "INFO"
+    POSTGRES_HOST: str = "localhost"
+    POSTGRES_USER: str = "postgres"
+    POSTGRES_PASS: str = ""
+    POSTGRES_NAME: str = "postgres"
 
     class Config:
         env_file = ".env"

--- a/cultist_chan_bot/core/database.py
+++ b/cultist_chan_bot/core/database.py
@@ -1,0 +1,37 @@
+"""Async PostgreSQL pool manager."""
+
+from __future__ import annotations
+
+import asyncpg
+
+from .config import Settings
+
+_POOL: asyncpg.Pool | None = None
+
+
+async def create_pool(settings: Settings) -> asyncpg.Pool:
+    """Initialize connection pool if needed."""
+    global _POOL
+    if _POOL is None:
+        _POOL = await asyncpg.create_pool(
+            host=settings.POSTGRES_HOST,
+            user=settings.POSTGRES_USER,
+            password=settings.POSTGRES_PASS,
+            database=settings.POSTGRES_NAME,
+        )
+    return _POOL
+
+
+def get_pool() -> asyncpg.Pool:
+    """Return initialized pool."""
+    if _POOL is None:
+        raise RuntimeError("Pool not initialized")
+    return _POOL
+
+
+async def close_pool() -> None:
+    """Close pool and reset state."""
+    global _POOL
+    if _POOL is not None:
+        await _POOL.close()
+        _POOL = None

--- a/cultist_chan_bot/db.py
+++ b/cultist_chan_bot/db.py
@@ -1,0 +1,2 @@
+from .core.db import *  # noqa: F401,F403
+

--- a/cultist_chan_bot/llm/__init__.py
+++ b/cultist_chan_bot/llm/__init__.py
@@ -1,0 +1,2 @@
+from .llm import generate_reply
+

--- a/cultist_chan_bot/llm/llm.py
+++ b/cultist_chan_bot/llm/llm.py
@@ -8,24 +8,36 @@ from typing import Any
 
 import aiohttp
 
-from .config import load_config
+from ..core.config import load_config
 
 _CFG = load_config()
 
 
-async def query_llm(prompt: str) -> str:
+async def generate_reply(
+    prompt: str,
+    session: aiohttp.ClientSession | None = None,
+) -> str:
     """Return TinyLlama result for the given prompt."""
+
+    async def _post(sess: aiohttp.ClientSession) -> str:
+        async with sess.post(
+            _CFG.LLM_URL,
+            json={"prompt": prompt},
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            resp.raise_for_status()
+            data: Any = await resp.json()
+            return str(data.get("response", "")).strip()
+
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                _CFG.LLM_URL,
-                json={"prompt": prompt},
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as resp:
-                resp.raise_for_status()
-                data: Any = await resp.json()
-                return str(data.get("response", "")).strip()
+        if session is None:
+            async with aiohttp.ClientSession() as sess:
+                return await _post(sess)
+        return await _post(session)
     except asyncio.TimeoutError as e:
         raise RuntimeError("LLM request timed out") from e
     except aiohttp.ClientError as e:
         raise RuntimeError(f"LLM request failed: {e}") from e
+
+
+query_llm = generate_reply

--- a/cultist_chan_bot/llm/persona.py
+++ b/cultist_chan_bot/llm/persona.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import asyncio
+import aiohttp
 
-from .llm import query_llm
-from .db import log_telemetry
+from .llm import generate_reply
+from ..core.db import log_telemetry
 from .memory import save_interaction, retrieve_context
 
-PROMPT_FILE = Path(__file__).with_name("prompts") / "telegram_reply.txt"
+PROMPT_FILE = Path(__file__).resolve().parents[1] / "prompts" / "telegram_reply.txt"
 
 
-def generate_persona_reply(event_type: str, context: dict) -> str:
+async def generate_persona_reply(
+    event_type: str,
+    context: dict,
+    session: aiohttp.ClientSession | None = None,
+) -> str:
     """Return TinyLlama-formatted persona reply."""
     template = PROMPT_FILE.read_text()
     payload = json.dumps({"event": event_type, "context": context})
@@ -33,8 +37,8 @@ def generate_persona_reply(event_type: str, context: dict) -> str:
     parts.append(payload)
     prompt = "\n".join(parts)
 
-    response = asyncio.run(query_llm(prompt))
-    log_telemetry(event_type, context, response)
+    response = await generate_reply(prompt, session=session)
+    await log_telemetry(event_type, context, response)
     if user_id is not None:
         message = context.get("text") or context.get("message") or ""
         save_interaction(user_id, message, response)

--- a/cultist_chan_bot/persona.py
+++ b/cultist_chan_bot/persona.py
@@ -1,0 +1,8 @@
+from .llm.persona import (
+    generate_persona_reply,
+    PROMPT_FILE,
+    retrieve_context,
+    save_interaction,
+)
+from .llm.llm import generate_reply
+

--- a/llm_gate/__init__.py
+++ b/llm_gate/__init__.py
@@ -1,0 +1,1 @@
+from .config import load_config, reload_config, is_critical_intent, is_allowed_contract

--- a/llm_gate/classifier.py
+++ b/llm_gate/classifier.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Intent classifier using local TinyLlama."""
+
+import re
+import requests
+
+from .config import load_config
+
+DEFAULT_URL = "http://localhost:8000/generate"
+
+
+def query_llm(prompt: str, url: str = DEFAULT_URL) -> str:
+    """Send prompt to TinyLlama and return response text."""
+    resp = requests.post(url, json={"prompt": prompt}, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    return str(data.get("response", "")).strip()
+
+
+def classify_request(user_input: str) -> dict:
+    """Return intent classification for the given text."""
+    cfg = load_config()
+    intents = cfg.get("critical_intents", [])
+    prompt = (
+        "Does the user intend to perform any of these actions: "
+        f"{', '.join(intents)}?\n{user_input}"
+    )
+    text = query_llm(prompt).lower()
+    match = re.search(r"intent=([a-zA-Z_]+)", text)
+    intent = match.group(1) if match else None
+    if intent not in intents:
+        intent = None
+    return {"is_critical": intent is not None, "matched_intent": intent}

--- a/llm_gate/config.py
+++ b/llm_gate/config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Config utilities for the gate."""
+
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path(__file__).with_name("config.yaml")
+_CONFIG: dict | None = None
+
+
+def load_config() -> dict:
+    """Load YAML configuration."""
+    global _CONFIG
+    if _CONFIG is None:
+        if CONFIG_PATH.exists():
+            with CONFIG_PATH.open() as fh:
+                _CONFIG = yaml.safe_load(fh) or {}
+        else:
+            _CONFIG = {}
+    return _CONFIG
+
+
+def reload_config() -> dict:
+    """Reload configuration from disk."""
+    global _CONFIG
+    _CONFIG = None
+    return load_config()
+
+
+def is_critical_intent(intent: str) -> bool:
+    cfg = load_config()
+    return intent in cfg.get("critical_intents", [])
+
+
+def is_allowed_contract(addr: str) -> bool:
+    cfg = load_config()
+    return addr in cfg.get("allowlist_contracts", [])

--- a/llm_gate/config.yaml
+++ b/llm_gate/config.yaml
@@ -1,0 +1,7 @@
+critical_intents:
+  - buy
+  - sell
+  - stake
+allowlist_contracts:
+  - 0xABC123...
+  - 0xDEF456...

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ pydantic-settings
 numpy>=1.21,<1.27
 aiohttp
 pytest-asyncio
+asyncpg
+testcontainers
 

--- a/tests/test_airdrop.py
+++ b/tests/test_airdrop.py
@@ -1,6 +1,9 @@
 from unittest import mock
 import importlib
 import sqlite3
+import pytest
+
+from cultist_chan_bot.airdrop_hunter import evaluate_airdrops, join_airdrop
 
 
 def _setup(tmp_path):
@@ -31,3 +34,27 @@ def test_get_airdrop_history(tmp_path):
     ad.save_airdrop_history('B', 'skipped', 2.0)
     rows = ad.get_airdrop_history()
     assert rows == [('B', 'skipped', 2.0), ('A', 'joined', 1.0)]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_airdrops_async():
+    drops = [{"name": "A"}, {"name": "B"}]
+    with mock.patch(
+        "cultist_chan_bot.airdrop.airdrop_hunter.generate_reply",
+        new=mock.AsyncMock(return_value='["A"]'),
+    ) as gen:
+        result = await evaluate_airdrops(drops)
+    assert result == [drops[0]]
+    gen.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_join_airdrop_logs():
+    drop = {"name": "Test"}
+    with mock.patch(
+        "cultist_chan_bot.airdrop.airdrop_hunter.log_airdrop",
+        new=mock.AsyncMock(),
+    ) as log:
+        result = await join_airdrop(drop)
+        log.assert_awaited_once_with(drop, "joined")
+    assert result == {"name": "Test", "success": True}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,30 @@
+from unittest import mock
+import importlib
+
+from llm_gate import config
+from llm_gate import classifier
+
+
+def mock_llm_response(text: str):
+    class Resp:
+        def json(self):
+            return {"response": text}
+
+        def raise_for_status(self):
+            pass
+
+    return mock.patch("llm_gate.classifier.requests.post", return_value=Resp())
+
+
+def test_classifier(tmp_path, monkeypatch):
+    file = tmp_path / "config.yaml"
+    file.write_text("critical_intents:\n  - buy\n")
+    monkeypatch.setattr(config, "CONFIG_PATH", file)
+    importlib.reload(config)
+    importlib.reload(classifier)
+
+    with mock_llm_response("intent=buy"):
+        result = classifier.classify_request("I want to buy ETH")
+
+    assert result["is_critical"] is True
+    assert result["matched_intent"] == "buy"

--- a/tests/test_core_database.py
+++ b/tests/test_core_database.py
@@ -1,0 +1,34 @@
+from unittest import mock
+import importlib
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_database_pool():
+    from cultist_chan_bot.core import database
+    importlib.reload(database)
+
+    settings = type(
+        'S',
+        (),
+        {
+            'POSTGRES_HOST': 'h',
+            'POSTGRES_USER': 'u',
+            'POSTGRES_PASS': 'p',
+            'POSTGRES_NAME': 'n',
+        },
+    )()
+
+    pool = mock.AsyncMock()
+    with mock.patch('asyncpg.create_pool', new=mock.AsyncMock(return_value=pool)) as create:
+        result = await database.create_pool(settings)
+    assert result is pool
+    assert database.get_pool() is pool
+
+    pool.close = mock.AsyncMock()
+    await database.close_pool()
+    pool.close.assert_awaited_once()
+    create.assert_awaited_once_with(
+        host='h', user='u', password='p', database='n'
+    )
+

--- a/tests/test_db_pg.py
+++ b/tests/test_db_pg.py
@@ -1,0 +1,29 @@
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+
+@pytest.mark.asyncio
+async def test_db_pg():
+    from cultist_chan_bot.core import database, db
+    from cultist_chan_bot.core.config import Settings
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        settings = Settings(
+            POSTGRES_HOST=pg.get_container_host_ip(),
+            POSTGRES_USER=pg.POSTGRES_USER,
+            POSTGRES_PASS=pg.POSTGRES_PASSWORD,
+            POSTGRES_NAME=pg.POSTGRES_DB,
+        )
+
+        await database.create_pool(settings)
+        await db.migrate_pg(settings)
+
+        await db.log_airdrop({"name": "Drop"}, "joined")
+        await db.log_telemetry("ev", {"k": 1}, "r")
+        await db.log_nft_purchase({"id": 1}, "ok", 1.0)
+        rows = await db.get_airdrop_history()
+
+        assert rows == [("Drop", "joined", pytest.approx(rows[0][2]))]
+
+        await database.close_pool()
+

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,13 +3,14 @@ from unittest import mock
 
 import asyncio
 from aiohttp import web
+import aiohttp
 import pytest
 
-from cultist_chan_bot.llm import query_llm
+from cultist_chan_bot.llm import generate_reply
 
 
 @pytest.mark.asyncio
-async def test_query_llm_returns_clean_response():
+async def test_generate_reply_returns_clean_response():
     async def handler(request: web.Request) -> web.Response:
         return web.json_response({'response': ' hi '})
 
@@ -22,10 +23,13 @@ async def test_query_llm_returns_clean_response():
     port = site._server.sockets[0].getsockname()[1]
     url = f'http://127.0.0.1:{port}/'
 
-    with mock.patch('cultist_chan_bot.llm._CFG') as cfg:
+    with mock.patch('cultist_chan_bot.llm.llm._CFG') as cfg:
         cfg.LLM_URL = url
-        result = await query_llm('hello')
+        result = await generate_reply('hello')
+        async with aiohttp.ClientSession() as sess:
+            second = await generate_reply('hi', session=sess)
     assert result == 'hi'
+    assert second == 'hi'
     await runner.cleanup()
 
 
@@ -33,10 +37,10 @@ async def test_query_llm_returns_clean_response():
 async def test_llm_async():
     with mock.patch('aiohttp.ClientSession.post', side_effect=asyncio.TimeoutError):
         with pytest.raises(RuntimeError, match='timed out'):
-            await query_llm('x')
+            await generate_reply('x')
 
     from aiohttp import ClientConnectionError
 
     with mock.patch('aiohttp.ClientSession.post', side_effect=ClientConnectionError('bad')):
         with pytest.raises(RuntimeError, match='failed'):
-            await query_llm('x')
+            await generate_reply('x')

--- a/tests/test_llm_gate_config.py
+++ b/tests/test_llm_gate_config.py
@@ -1,0 +1,14 @@
+from llm_gate import config
+import importlib
+
+
+def test_config(tmp_path, monkeypatch):
+    file = tmp_path / "config.yaml"
+    file.write_text(
+        """\ncritical_intents:\n  - buy\nallowlist_contracts:\n  - 0xABC123...\n"""
+    )
+    monkeypatch.setattr(config, "CONFIG_PATH", file)
+    importlib.reload(config)
+    assert config.is_critical_intent("buy")
+    assert config.is_allowed_contract("0xABC123...")
+    assert not config.is_critical_intent("chat")

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -1,37 +1,40 @@
 from unittest import mock
 import json
 
+import pytest
 from cultist_chan_bot.persona import generate_persona_reply, PROMPT_FILE
 
 
 
-def test_generate_persona_reply_formatting():
+@pytest.mark.asyncio
+async def test_generate_persona_reply_formatting():
     context = {"text": "hi"}
     with mock.patch(
-        "cultist_chan_bot.persona.query_llm",
+        "cultist_chan_bot.llm.persona.generate_reply",
         new=mock.AsyncMock(return_value="yo"),
     ) as q, \
-         mock.patch("cultist_chan_bot.persona.retrieve_context", return_value=[]), \
-         mock.patch("cultist_chan_bot.persona.save_interaction"):
-        result = generate_persona_reply("message", context)
+         mock.patch("cultist_chan_bot.llm.persona.retrieve_context", return_value=[]), \
+         mock.patch("cultist_chan_bot.llm.persona.save_interaction"):
+        result = await generate_persona_reply("message", context)
         assert result == "yo"
         expected = PROMPT_FILE.read_text() + "\n" + json.dumps({"event": "message", "context": context})
-        q.assert_called_once_with(expected)
+        q.assert_awaited_once_with(expected)
 
 
-def test_log_telemetry(tmp_path):
+@pytest.mark.asyncio
+async def test_log_telemetry(tmp_path):
     db_path = tmp_path / "t.db"
     import importlib
     import cultist_chan_bot.db as db
     importlib.reload(db)
     db.init_db(str(db_path))
     with mock.patch(
-        "cultist_chan_bot.persona.query_llm",
+        "cultist_chan_bot.llm.persona.generate_reply",
         new=mock.AsyncMock(return_value="ok"),
     ), \
-         mock.patch("cultist_chan_bot.persona.retrieve_context", return_value=[]), \
-         mock.patch("cultist_chan_bot.persona.save_interaction"):
-        result = generate_persona_reply("event", {"a": 1})
+         mock.patch("cultist_chan_bot.llm.persona.retrieve_context", return_value=[]), \
+         mock.patch("cultist_chan_bot.llm.persona.save_interaction"):
+        result = await generate_persona_reply("event", {"a": 1})
         assert result == "ok"
         import sqlite3
         import json as js
@@ -44,32 +47,34 @@ def test_log_telemetry(tmp_path):
         assert row[2] == "ok"
 
 
-def test_generate_reply_with_memory():
+@pytest.mark.asyncio
+async def test_generate_reply_with_memory():
     context = {"user_id": 5, "text": "yo"}
     memory = [
         {"message": "hi", "reply": "hey"},
         {"message": "sup", "reply": "ok"},
     ]
-    with mock.patch("cultist_chan_bot.persona.retrieve_context", return_value=memory), \
+    with mock.patch("cultist_chan_bot.llm.persona.retrieve_context", return_value=memory), \
          mock.patch(
-             "cultist_chan_bot.persona.query_llm",
+             "cultist_chan_bot.llm.persona.generate_reply",
              new=mock.AsyncMock(return_value="ok"),
          ) as q, \
-         mock.patch("cultist_chan_bot.persona.save_interaction"):
-        generate_persona_reply("msg", context)
+         mock.patch("cultist_chan_bot.llm.persona.save_interaction"):
+        await generate_persona_reply("msg", context)
         prompt = q.call_args[0][0]
     assert "User: hi\nBot: hey" in prompt
     assert "User: sup\nBot: ok" in prompt
 
 
-def test_save_reply_to_memory():
+@pytest.mark.asyncio
+async def test_save_reply_to_memory():
     context = {"user_id": 9, "text": "hello"}
     with mock.patch(
-        "cultist_chan_bot.persona.query_llm",
+        "cultist_chan_bot.llm.persona.generate_reply",
         new=mock.AsyncMock(return_value="hi"),
     ), \
-         mock.patch("cultist_chan_bot.persona.retrieve_context", return_value=[]), \
-         mock.patch("cultist_chan_bot.persona.save_interaction") as save:
-        result = generate_persona_reply("msg", context)
+         mock.patch("cultist_chan_bot.llm.persona.retrieve_context", return_value=[]), \
+         mock.patch("cultist_chan_bot.llm.persona.save_interaction") as save:
+        result = await generate_persona_reply("msg", context)
     assert result == "hi"
     save.assert_called_once_with(9, "hello", "hi")


### PR DESCRIPTION
## Summary
- implement a simple YAML configuration loader for llm gate
- expose helper functions to check intents and contract addresses
- provide default config with example entries
- add local TinyLlama intent classifier
- test configuration helpers and classifier logic

## Testing
- `pytest tests/test_llm_gate_config.py tests/test_classifier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6df68dc8832e89463aed77fbe59a